### PR TITLE
fix(paydunya): correct sandbox API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ const africaPayments = new AfricaPayments(
     store: {
       name: "Electronics Shop",
     },
+    callbackUrl: "https://example.com/payments/paydunya/webhook",
   })
 );
 ```
+
+Use `mode: "test"` to send Paydunya requests to the official sandbox API
+base URL: `https://app.paydunya.com/sandbox-api/`.
 
 - Checkout so your users can pay
 
@@ -78,12 +82,12 @@ africaPayments.on(PaymentEventType.PAYMENT_SUCCESSFUL, async (event) => {
 });
 ```
 
-
 ## Test with the bogus payment provider
 
 In a testing environment, you do not want to make actual payments. Not all payment providers provide a sandbox mode and even when they do, not all of the features in the sandbox are testable. For integration tests you most likely don't want to involve external APIs, even sandbox ones.
 
 That's why we made a `BogusPaymentProvider` that fakes all the checkout methods and webhook handling logic. It follows simple rules:
+
 - For mobile money checkout, any phone number that ends with `13` will trigger a payment failure event and redirect to the failure url
 - For credit card checkout, any card number that ends with `13` will trigger a payment failure event and redirect to the failure url
 - For redirect checkout, any email that ends with `@failure.com` will trigger a payment failure event and redirect to the failure url

--- a/src/sdk/providers/__tests__/__snapshots__/paydunya.test.ts.snap
+++ b/src/sdk/providers/__tests__/__snapshots__/paydunya.test.ts.snap
@@ -150,7 +150,7 @@ exports[`calls paydunya cc API and returns a checkout result on success 1`] = `
 
 exports[`calls paydunya cc API and returns a checkout result on success 2`] = `
 {
-  "redirectUrl": "https://app.paydunya.com/sandbox/checkout/invoice/token",
+  "redirectUrl": "https://app.paydunya.com/sandbox-checkout/invoice/token",
   "transactionAmount": 100,
   "transactionCurrency": "XOF",
   "transactionId": "transactionId",

--- a/src/sdk/providers/__tests__/paydunya.test.ts
+++ b/src/sdk/providers/__tests__/paydunya.test.ts
@@ -51,6 +51,47 @@ afterEach(() => {
   mockApi.reset();
 });
 
+test("uses the official Paydunya sandbox API base URL in test mode", async () => {
+  paydunyaPaymentProvider = new PaydunyaPaymentProvider({
+    masterKey: "masterKey",
+    mode: "test",
+    privateKey: "privateKey",
+    publicKey: "publicKey",
+    store: {
+      name: "store-name",
+    },
+    token: "token",
+    callbackUrl: "https://example.com/callback",
+  });
+  mockApi
+    .onPost("/v1/checkout-invoice/create")
+    .replyOnce(200, createInvoiceSuccessResponse);
+  mockApi
+    .onPost("/v1/softpay/wave-senegal")
+    .replyOnce(200, wavePaymentSuccessResponse);
+
+  await paydunyaPaymentProvider.checkoutMobileMoney({
+    amount: 100,
+    currency: Currency.XOF,
+    customer: {
+      firstName: "Mamadou",
+      lastName: "Diallo",
+      phoneNumber: "+221781234567",
+    },
+    description: "description",
+    paymentMethod: PaymentMethod.WAVE,
+    transactionId: "transactionId",
+  });
+
+  expect(mockApi.history.post).toHaveLength(2);
+  expect(mockApi.history.post[0].baseURL).toBe(
+    "https://app.paydunya.com/sandbox-api/",
+  );
+  expect(mockApi.history.post[1].baseURL).toBe(
+    "https://app.paydunya.com/sandbox-api/",
+  );
+});
+
 test("calls wave API and returns a checkout result on success", async () => {
   mockApi
     .onPost("/v1/checkout-invoice/create")
@@ -189,7 +230,7 @@ test("throws unsupported payment method error when using checkout redirect", asy
       transactionId: "transactionId",
       successRedirectUrl: "https://example.com/success",
       failureRedirectUrl: "https://example.com/failure",
-    })
+    }),
   ).rejects.toThrowErrorMatchingSnapshot();
 });
 
@@ -266,7 +307,7 @@ describe("Orange Money flow detection", () => {
     });
 
     const orangeMoneyRequest = mockApi.history.post.find(
-      (req) => req.url === "/v1/softpay/new-orange-money-senegal"
+      (req) => req.url === "/v1/softpay/new-orange-money-senegal",
     );
     const requestData = JSON.parse(orangeMoneyRequest?.data || "{}");
 
@@ -297,7 +338,7 @@ describe("Orange Money flow detection", () => {
     });
 
     const orangeMoneyRequest = mockApi.history.post.find(
-      (req) => req.url === "/v1/softpay/new-orange-money-senegal"
+      (req) => req.url === "/v1/softpay/new-orange-money-senegal",
     );
     const requestData = JSON.parse(orangeMoneyRequest?.data || "{}");
 
@@ -328,7 +369,7 @@ describe("Orange Money flow detection", () => {
     });
 
     const orangeMoneyRequest = mockApi.history.post.find(
-      (req) => req.url === "/v1/softpay/new-orange-money-senegal"
+      (req) => req.url === "/v1/softpay/new-orange-money-senegal",
     );
     const requestData = JSON.parse(orangeMoneyRequest?.data || "{}");
 
@@ -361,7 +402,7 @@ describe("Orange Money request payload builder", () => {
     });
 
     const orangeMoneyRequest = mockApi.history.post.find(
-      (req) => req.url === "/v1/softpay/new-orange-money-senegal"
+      (req) => req.url === "/v1/softpay/new-orange-money-senegal",
     );
     const requestData = JSON.parse(orangeMoneyRequest?.data || "{}");
 
@@ -396,7 +437,7 @@ describe("Orange Money request payload builder", () => {
     });
 
     const orangeMoneyRequest = mockApi.history.post.find(
-      (req) => req.url === "/v1/softpay/new-orange-money-senegal"
+      (req) => req.url === "/v1/softpay/new-orange-money-senegal",
     );
     const requestData = JSON.parse(orangeMoneyRequest?.data || "{}");
 
@@ -433,7 +474,7 @@ describe("Orange Money QR code payment flow", () => {
     });
 
     expect(checkoutResult.redirectUrl).toBe(
-      "https://qr.paydunya.com/checkout?token=qr-token-123"
+      "https://qr.paydunya.com/checkout?token=qr-token-123",
     );
     expect(checkoutResult.transactionStatus).toBe(TransactionStatus.PENDING);
     expect(checkoutResult.transactionAmount).toBe(5000);
@@ -492,7 +533,7 @@ describe("Orange Money QR code payment flow", () => {
         paymentMethod: PaymentMethod.ORANGE_MONEY,
         transactionId: "test-txn-qr-error",
         // No authorizationCode - triggers QRCODE flow
-      })
+      }),
     ).rejects.toThrow("Payment processing failed");
   });
 
@@ -520,7 +561,7 @@ describe("Orange Money QR code payment flow", () => {
     // Verify that redirectUrl is properly included in CheckoutResult
     expect(checkoutResult).toHaveProperty("redirectUrl");
     expect(checkoutResult.redirectUrl).toBe(
-      "https://qr.paydunya.com/checkout?token=qr-token-123"
+      "https://qr.paydunya.com/checkout?token=qr-token-123",
     );
 
     // Verify all other required fields are present
@@ -599,7 +640,7 @@ describe("Backward compatibility", () => {
 
     // Verify the request was made with OTPCODE api_type
     const orangeMoneyRequest = mockApi.history.post.find(
-      (req) => req.url === "/v1/softpay/new-orange-money-senegal"
+      (req) => req.url === "/v1/softpay/new-orange-money-senegal",
     );
     const requestData = JSON.parse(orangeMoneyRequest?.data || "{}");
     expect(requestData.api_type).toBe("OTPCODE");
@@ -608,7 +649,7 @@ describe("Backward compatibility", () => {
     // Verify the result structure matches expected format
     expect(checkoutResult.transactionId).toBe("test-backward-compat-001");
     expect(checkoutResult.transactionReference).toBe(
-      createInvoiceSuccessResponse.token
+      createInvoiceSuccessResponse.token,
     );
     expect(checkoutResult.transactionStatus).toBe(TransactionStatus.PENDING);
     expect(checkoutResult.transactionAmount).toBe(5000);
@@ -640,7 +681,7 @@ describe("Backward compatibility", () => {
         paymentMethod: PaymentMethod.ORANGE_MONEY,
         transactionId: "test-invalid-otp",
         authorizationCode: "invalid-code",
-      })
+      }),
     ).rejects.toThrow("Invalid or expired OTP code!");
   });
 
@@ -666,7 +707,7 @@ describe("Backward compatibility", () => {
         paymentMethod: PaymentMethod.ORANGE_MONEY,
         transactionId: "test-server-error",
         authorizationCode: "123456",
-      })
+      }),
     ).rejects.toThrow("Internal server error");
   });
 
@@ -684,7 +725,7 @@ describe("Backward compatibility", () => {
         paymentMethod: PaymentMethod.ORANGE_MONEY,
         transactionId: "test-invalid-phone",
         authorizationCode: "123456",
-      })
+      }),
     ).rejects.toThrow();
   });
 });

--- a/src/sdk/providers/fixtures/paydunya.fixtures.ts
+++ b/src/sdk/providers/fixtures/paydunya.fixtures.ts
@@ -19,7 +19,7 @@ export const creditCardInvoiceSuccessResponse: PaydunyaCreateInvoiceSuccessRespo
   {
     description: "description",
     response_code: "00",
-    response_text: "https://app.paydunya.com/sandbox/checkout/invoice/token",
+    response_text: "https://app.paydunya.com/sandbox-checkout/invoice/token",
     token: "token",
   };
 
@@ -54,39 +54,40 @@ export const orangeMoneyQrCodeSuccessResponseWithoutUrl: PaydunyaOrangeMoneyPaym
     success: true,
   };
 
-export const getWaveInvoiceSuccessResponse: PaydunyaGetInvoiceSuccessResponse = {
-  actions: {
-    cancel_url: "https://example.com/cancel",
-    return_url: "https://example.com/return",
-    callback_url: "https://example.com/callback",
-  },
-  custom_data: {
-    text_meta: "value",
-    number_meta: 1,
-    boolean_meta: true,
-  },
-  customer: {
-    name: "Mamadou Diallo",
-    email: "mamadou.diallo@yopmail.com",
-    payment_method: "wave_senegal",
-    phone: "+221781234567",
-  },
-  fail_reason: "",
-  hash: "hash",
-  invoice: {
-    description: "description",
-    expire_date: "2021-08-31T00:00:00.000Z",
-    pal_is_on: "",
-    token: "token",
-    total_amount: "100",
-    total_amount_without_fees: "100",
-  },
-  mode: "live",
-  receipt_url: "https://example.com/receipt",
-  response_code: "00",
-  response_text: "success",
-  status: "completed",
-};
+export const getWaveInvoiceSuccessResponse: PaydunyaGetInvoiceSuccessResponse =
+  {
+    actions: {
+      cancel_url: "https://example.com/cancel",
+      return_url: "https://example.com/return",
+      callback_url: "https://example.com/callback",
+    },
+    custom_data: {
+      text_meta: "value",
+      number_meta: 1,
+      boolean_meta: true,
+    },
+    customer: {
+      name: "Mamadou Diallo",
+      email: "mamadou.diallo@yopmail.com",
+      payment_method: "wave_senegal",
+      phone: "+221781234567",
+    },
+    fail_reason: "",
+    hash: "hash",
+    invoice: {
+      description: "description",
+      expire_date: "2021-08-31T00:00:00.000Z",
+      pal_is_on: "",
+      token: "token",
+      total_amount: "100",
+      total_amount_without_fees: "100",
+    },
+    mode: "live",
+    receipt_url: "https://example.com/receipt",
+    response_code: "00",
+    response_text: "success",
+    status: "completed",
+  };
 
 export const createDisburseInvoiceSuccessResponse: PaydunyaCreateDisburseInvoiceSuccessResponse =
   {

--- a/src/sdk/providers/paydunya.ts
+++ b/src/sdk/providers/paydunya.ts
@@ -36,7 +36,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
     this.api = create({
       baseURL:
         config.mode === "test"
-          ? "https://app.sandbox.paydunya.com/api/"
+          ? "https://app.paydunya.com/sandbox-api/"
           : "https://app.paydunya.com/api/",
       headers: {
         "Content-Type": "application/json",
@@ -55,7 +55,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
       ) {
         throw new PaymentError(
           response.data.message,
-          PaymentErrorType.INVALID_AUTHORIZATION_CODE
+          PaymentErrorType.INVALID_AUTHORIZATION_CODE,
         );
       }
       if (!response.ok) {
@@ -72,9 +72,9 @@ class PaydunyaPaymentProvider implements PaymentProvider {
             ? "message" in response.data
               ? String(response.data.message)
               : "response_text" in response.data
-              ? String(response.data.response_text)
-              : defaultErrorMessage
-            : defaultErrorMessage
+                ? String(response.data.response_text)
+                : defaultErrorMessage
+            : defaultErrorMessage,
         );
       }
     });
@@ -89,7 +89,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
   }
 
   private determineOrangeMoneyApiType(
-    options: OrangeMoneyCheckoutOptions
+    options: OrangeMoneyCheckoutOptions,
   ): PaydunyaOrangeMoneyApiType {
     return options.authorizationCode ? "OTPCODE" : "QRCODE";
   }
@@ -97,7 +97,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
   private buildOrangeMoneyRequest(
     options: OrangeMoneyCheckoutOptions,
     invoiceToken: string,
-    parsedPhoneNumber: PhoneNumber
+    parsedPhoneNumber: PhoneNumber,
   ): PaydunyaOrangeMoneyRequest {
     const apiType = this.determineOrangeMoneyApiType(options);
     const basePayload = {
@@ -125,12 +125,12 @@ class PaydunyaPaymentProvider implements PaymentProvider {
   }
 
   async checkout(
-    options: MobileMoneyCheckoutOptions | CreditCardCheckoutOptions
+    options: MobileMoneyCheckoutOptions | CreditCardCheckoutOptions,
   ): Promise<CheckoutResult> {
     if (options.currency !== Currency.XOF) {
       throw new PaymentError(
         "Paydunya does not support the currency: " + options.currency,
-        PaymentErrorType.UNSUPPORTED_PAYMENT_METHOD
+        PaymentErrorType.UNSUPPORTED_PAYMENT_METHOD,
       );
     }
     const isMobileMoney =
@@ -163,7 +163,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
     if (!invoiceData) {
       throw new PaymentError(
-        "Paydunya error: " + createInvoiceResponse.problem
+        "Paydunya error: " + createInvoiceResponse.problem,
       );
     }
 
@@ -174,7 +174,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
     if (!("token" in invoiceData)) {
       throw new PaymentError(
         "Missing invoice token in Paydunya response: " +
-          invoiceData.response_text
+          invoiceData.response_text,
       );
     }
 
@@ -188,18 +188,18 @@ class PaydunyaPaymentProvider implements PaymentProvider {
     if (isMobileMoney) {
       const parsedCustomerPhoneNumber = parsePhoneNumber(
         options.customer.phoneNumber,
-        "SN"
+        "SN",
       );
       if (!parsedCustomerPhoneNumber.isValid()) {
         throw new PaymentError(
           "Invalid phone number: " + options.customer.phoneNumber,
-          PaymentErrorType.INVALID_PHONE_NUMBER
+          PaymentErrorType.INVALID_PHONE_NUMBER,
         );
       }
       if (!parsedCustomerPhoneNumber.isPossible()) {
         throw new PaymentError(
           "Phone number is not possible: " + options.customer.phoneNumber,
-          PaymentErrorType.INVALID_PHONE_NUMBER
+          PaymentErrorType.INVALID_PHONE_NUMBER,
         );
       }
 
@@ -220,7 +220,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
         if (!waveData) {
           throw new PaymentError(
-            "Paydunya error: " + paydunyaWaveResponse.problem
+            "Paydunya error: " + paydunyaWaveResponse.problem,
           );
         }
 
@@ -230,7 +230,8 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
         if (!waveData.url) {
           throw new PaymentError(
-            "Missing wave payment url in Paydunya response: " + waveData.message
+            "Missing wave payment url in Paydunya response: " +
+              waveData.message,
           );
         }
         paydunyaPaymentResponse = waveData;
@@ -238,7 +239,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
         const requestPayload = this.buildOrangeMoneyRequest(
           options,
           invoiceToken,
-          parsedCustomerPhoneNumber
+          parsedCustomerPhoneNumber,
         );
 
         const paydunyaOrangeMoneyResponse = await this.api.post<
@@ -250,7 +251,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
         if (!orangeMoneyData) {
           throw new PaymentError(
-            "Paydunya error: " + paydunyaOrangeMoneyResponse.problem
+            "Paydunya error: " + paydunyaOrangeMoneyResponse.problem,
           );
         }
 
@@ -305,30 +306,30 @@ class PaydunyaPaymentProvider implements PaymentProvider {
     };
     this.eventEmitter?.emit(
       PaymentEventType.PAYMENT_INITIATED,
-      paymentInitiatedEvent
+      paymentInitiatedEvent,
     );
 
     return result;
   }
 
   async checkoutMobileMoney(
-    options: MobileMoneyCheckoutOptions
+    options: MobileMoneyCheckoutOptions,
   ): Promise<CheckoutResult> {
     return this.checkout(options);
   }
 
   async checkoutCreditCard(
-    options: CreditCardCheckoutOptions
+    options: CreditCardCheckoutOptions,
   ): Promise<CheckoutResult> {
     return this.checkout(options);
   }
 
   async checkoutRedirect(
-    options: RedirectCheckoutOptions
+    options: RedirectCheckoutOptions,
   ): Promise<CheckoutResult> {
     throw new PaymentError(
       "Paydunya redirect checkout not yet implemented",
-      PaymentErrorType.UNSUPPORTED_PAYMENT_METHOD
+      PaymentErrorType.UNSUPPORTED_PAYMENT_METHOD,
     );
   }
 
@@ -345,14 +346,14 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
     if (getInvoiceResponse.data.response_code !== "00") {
       throw new PaymentError(
-        "Paydunya error: " + getInvoiceResponse.data.response_text
+        "Paydunya error: " + getInvoiceResponse.data.response_text,
       );
     }
 
     if (!("invoice" in getInvoiceResponse.data)) {
       throw new PaymentError(
         "Missing invoice in Paydunya response: " +
-          getInvoiceResponse.data.response_text
+          getInvoiceResponse.data.response_text,
       );
     }
 
@@ -367,7 +368,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
       amount: amountToRefund,
       withdraw_mode: getInvoiceResponse.data.customer.payment_method.replace(
         /_/g,
-        "-"
+        "-",
       ),
       disburse_id: options.transactionId,
       callback_url: this.config.callbackUrl,
@@ -375,20 +376,20 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
     if (!createDisburseInvoiceResponse.data) {
       throw new PaymentError(
-        "Paydunya error: " + createDisburseInvoiceResponse.problem
+        "Paydunya error: " + createDisburseInvoiceResponse.problem,
       );
     }
 
     if (createDisburseInvoiceResponse.data.response_code !== "00") {
       throw new PaymentError(
-        "Paydunya error: " + createDisburseInvoiceResponse.data.response_text
+        "Paydunya error: " + createDisburseInvoiceResponse.data.response_text,
       );
     }
 
     if (!("disburse_token" in createDisburseInvoiceResponse.data)) {
       throw new PaymentError(
         "Missing disburse token in Paydunya response: " +
-          createDisburseInvoiceResponse.data.response_text
+          createDisburseInvoiceResponse.data.response_text,
       );
     }
 
@@ -402,13 +403,13 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
     if (!submitDisburseInvoiceResponse.data) {
       throw new PaymentError(
-        "Paydunya error: " + submitDisburseInvoiceResponse.problem
+        "Paydunya error: " + submitDisburseInvoiceResponse.problem,
       );
     }
 
     if (submitDisburseInvoiceResponse.data.response_code !== "00") {
       throw new PaymentError(
-        "Paydunya error: " + submitDisburseInvoiceResponse.data.response_text
+        "Paydunya error: " + submitDisburseInvoiceResponse.data.response_text,
       );
     }
 
@@ -422,7 +423,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
   }
 
   async payoutMobileMoney(
-    options: MobileMoneyPayoutOptions
+    options: MobileMoneyPayoutOptions,
   ): Promise<PayoutResult> {
     const paymentMethodToWithdrawMode: Record<
       MobileMoneyPayoutOptions["paymentMethod"],
@@ -434,18 +435,18 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
     const parsedRecipientPhoneNumber = parsePhoneNumber(
       options.recipient.phoneNumber,
-      "SN"
+      "SN",
     );
     if (!parsedRecipientPhoneNumber.isValid()) {
       throw new PaymentError(
         "Invalid phone number: " + options.recipient.phoneNumber,
-        PaymentErrorType.INVALID_PHONE_NUMBER
+        PaymentErrorType.INVALID_PHONE_NUMBER,
       );
     }
     if (!parsedRecipientPhoneNumber.isPossible()) {
       throw new PaymentError(
         "Phone number is not possible: " + options.recipient.phoneNumber,
-        PaymentErrorType.INVALID_PHONE_NUMBER
+        PaymentErrorType.INVALID_PHONE_NUMBER,
       );
     }
 
@@ -462,20 +463,20 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
     if (!createDisburseInvoiceResponse.data) {
       throw new PaymentError(
-        "Paydunya error: " + createDisburseInvoiceResponse.problem
+        "Paydunya error: " + createDisburseInvoiceResponse.problem,
       );
     }
 
     if (createDisburseInvoiceResponse.data.response_code !== "00") {
       throw new PaymentError(
-        "Paydunya error: " + createDisburseInvoiceResponse.data.response_text
+        "Paydunya error: " + createDisburseInvoiceResponse.data.response_text,
       );
     }
 
     if (!("disburse_token" in createDisburseInvoiceResponse.data)) {
       throw new PaymentError(
         "Missing disburse token in Paydunya response: " +
-          createDisburseInvoiceResponse.data.response_text
+          createDisburseInvoiceResponse.data.response_text,
       );
     }
 
@@ -489,13 +490,13 @@ class PaydunyaPaymentProvider implements PaymentProvider {
 
     if (!submitDisburseInvoiceResponse.data) {
       throw new PaymentError(
-        "Paydunya error: " + submitDisburseInvoiceResponse.problem
+        "Paydunya error: " + submitDisburseInvoiceResponse.problem,
       );
     }
 
     if (submitDisburseInvoiceResponse.data.response_code !== "00") {
       throw new PaymentError(
-        "Paydunya error: " + submitDisburseInvoiceResponse.data.response_text
+        "Paydunya error: " + submitDisburseInvoiceResponse.data.response_text,
       );
     }
 
@@ -511,7 +512,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
   async handleWebhook(rawBody: Buffer | string | Record<string, unknown>) {
     if (isBuffer(rawBody) || isString(rawBody)) {
       console.error(
-        "Paydunya webhook body must be a parsed object, not the raw body"
+        "Paydunya webhook body must be a parsed object, not the raw body",
       );
       return null;
     }
@@ -530,8 +531,8 @@ class PaydunyaPaymentProvider implements PaymentProvider {
       body.customer.payment_method === "wave_senegal"
         ? PaymentMethod.WAVE
         : body.customer.payment_method === "orange_money_senegal"
-        ? PaymentMethod.ORANGE_MONEY
-        : null;
+          ? PaymentMethod.ORANGE_MONEY
+          : null;
 
     if (body.status === "completed" && body.response_code == "00") {
       const paymentSuccessfulEvent: PaymentSuccessfulEvent = {
@@ -546,7 +547,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
       };
       this.eventEmitter?.emit(
         PaymentEventType.PAYMENT_SUCCESSFUL,
-        paymentSuccessfulEvent
+        paymentSuccessfulEvent,
       );
       return paymentSuccessfulEvent;
     } else if (body.status === "cancelled") {
@@ -563,7 +564,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
       };
       this.eventEmitter?.emit(
         PaymentEventType.PAYMENT_CANCELLED,
-        paymentCancelledEvent
+        paymentCancelledEvent,
       );
       return paymentCancelledEvent;
     } else if (body.status === "failed") {
@@ -580,7 +581,7 @@ class PaydunyaPaymentProvider implements PaymentProvider {
       };
       this.eventEmitter?.emit(
         PaymentEventType.PAYMENT_FAILED,
-        paymentFailedEvent
+        paymentFailedEvent,
       );
       return paymentFailedEvent;
     }


### PR DESCRIPTION
## Summary

- Correct the Paydunya sandbox `baseURL` from the unofficial
  `https://app.sandbox.paydunya.com/api/` to the PayDunya-documented
  `https://app.paydunya.com/sandbox-api/` (see
  [PayDunya HTTP/JSON docs](https://developers.paydunya.com/doc/EN/http_json)
  and [Sandbox SoftPay docs](https://developers.paydunya.com/doc/FR/sandbox_softpay)).
- Fix the credit card fixture `response_text` from
  `.../sandbox/checkout/...` to `.../sandbox-checkout/...` to match the
  documented sandbox redirect URL pattern.
- Add a dedicated Jest test ensuring `mode: "test"` sends all requests
  through the correct sandbox base URL.
- Document `callbackUrl` (required field missing from the README example)
  and add a note about `mode: "test"` sandbox behaviour.

Closes #1

## Test plan

- [ ] `npm test` — all 22 tests pass, 1 snapshot updated
- [ ] `npm run build` — TypeScript compilation succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Paydunya Quick Start configuration with `callbackUrl` field example
  * Clarified sandbox mode setup instructions

* **Bug Fixes**
  * Corrected Paydunya sandbox API endpoint for test mode
  * Enhanced error handling for phone number validation failures
  * Improved OTP validation error responses

* **Tests**
  * Added verification test for sandbox API endpoint usage in test mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->